### PR TITLE
Add think tool for internal reasoning

### DIFF
--- a/polyagent/alembic/seed_data/servers.json
+++ b/polyagent/alembic/seed_data/servers.json
@@ -88,5 +88,14 @@
     "command": "uv",
     "args": ["run", "python", "-m", "src.mcp_servers.servers.trigger_server"],
     "created_by_principal_id": "a603702c-1e2f-4324-bd98-3c8e3232b477"
+  },
+  {
+    "name": "think",
+    "description": "Internal reasoning tool: think through problems step by step without executing actions.",
+    "server_type": "system",
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "-m", "src.mcp_servers.servers.think_server"],
+    "created_by_principal_id": "a603702c-1e2f-4324-bd98-3c8e3232b477"
   }
 ]

--- a/polyagent/alembic/versions/f20c1f86da82_add_think_server.py
+++ b/polyagent/alembic/versions/f20c1f86da82_add_think_server.py
@@ -1,0 +1,84 @@
+"""add think server
+
+Revision ID: f20c1f86da82
+Revises: 0d9538be39e0
+Create Date: 2025-12-23 22:32:15.875703
+
+"""
+
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f20c1f86da82"
+down_revision: Union[str, Sequence[str], None] = "0d9538be39e0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# System principal UUID (used for system servers)
+SYSTEM_PRINCIPAL_ID = "a603702c-1e2f-4324-bd98-3c8e3232b477"
+
+
+def upgrade() -> None:
+    """Add think server to the servers table."""
+    conn = op.get_bind()
+
+    # Check if think server already exists
+    result = conn.execute(sa.text("SELECT id FROM servers WHERE name = 'think'"))
+    if result.fetchone():
+        return  # Already exists
+
+    # Insert think server
+    conn.execute(
+        sa.text(
+            "INSERT INTO servers (name, description, server_type, transport, command, args, "
+            "created_by_principal_id, is_active, created_at) "
+            "VALUES (:name, :description, :server_type, :transport, :command, :args, "
+            ":created_by_principal_id, true, NOW())"
+        ),
+        {
+            "name": "think",
+            "description": "Internal reasoning tool: think through problems step by step without executing actions.",
+            "server_type": "system",
+            "transport": "stdio",
+            "command": "uv",
+            "args": json.dumps(["run", "python", "-m", "src.mcp_servers.servers.think_server"]),
+            "created_by_principal_id": SYSTEM_PRINCIPAL_ID,
+        },
+    )
+
+    # Grant think server to all existing agents
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO agent_servers (agent_id, server_id, granted_at)
+            SELECT a.id, s.id, NOW()
+            FROM agents a
+            CROSS JOIN servers s
+            WHERE s.name = 'think'
+            AND NOT EXISTS (
+                SELECT 1 FROM agent_servers ags
+                WHERE ags.agent_id = a.id AND ags.server_id = s.id
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Remove think server."""
+    conn = op.get_bind()
+
+    # Remove agent_servers grants for think server
+    conn.execute(
+        sa.text(
+            "DELETE FROM agent_servers WHERE server_id = (SELECT id FROM servers WHERE name = 'think')"
+        )
+    )
+
+    # Remove think server
+    conn.execute(sa.text("DELETE FROM servers WHERE name = 'think'"))

--- a/polyagent/src/mcp_servers/servers/think_server.py
+++ b/polyagent/src/mcp_servers/servers/think_server.py
@@ -1,0 +1,37 @@
+"""MCP server for the think tool.
+
+The think tool allows agents to perform internal reasoning without executing
+external actions. This is useful for complex reasoning, planning, and
+maintaining context during multi-step tasks.
+"""
+
+from fastmcp import FastMCP
+
+mcp = FastMCP("think")
+
+
+@mcp.tool()
+def think(thought: str) -> dict:
+    """Use this tool to think through a problem step by step.
+
+    This tool does not execute any external actions or retrieve new information.
+    It simply allows you to reason through complex problems, plan your approach,
+    or organize your thoughts before taking action.
+
+    Use cases:
+    - Breaking down complex problems into steps
+    - Planning a sequence of actions before executing them
+    - Reasoning about trade-offs between different approaches
+    - Reflecting on results and deciding next steps
+
+    Args:
+        thought: Your internal reasoning or thought process
+    """
+    return {
+        "success": True,
+        "thought_length": len(thought),
+    }
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

- Add a `think` MCP server that provides a tool for internal reasoning
- The think tool allows agents to reason through complex problems step by step without executing external actions
- Useful for planning, breaking down problems, and organizing thoughts before taking action

## Changes

- `polyagent/src/mcp_servers/servers/think_server.py` - New MCP server with the think tool
- `polyagent/alembic/seed_data/servers.json` - Added think server to seed data
- `polyagent/alembic/versions/f20c1f86da82_add_think_server.py` - Migration to add think server and grant to existing agents

## Test plan

- [x] Apply migration: `uv run python -m alembic upgrade head`
- [x] Verify server exists: `SELECT * FROM servers WHERE name = 'think';`
- [x] Verify grants: `SELECT * FROM agent_servers WHERE server_id = (SELECT id FROM servers WHERE name = 'think');`
- [x] Test tool via agent execution

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)